### PR TITLE
Metadata

### DIFF
--- a/lib/aot_jobs/importer.ex
+++ b/lib/aot_jobs/importer.ex
@@ -67,7 +67,7 @@ defmodule AotJobs.Importer do
   end
 
   defp ensure_clean_paths!(tarball) do
-    _ = System.cmd("rm", ["-r", @dirname])
+    if File.exists?(@dirname), do: _ = System.cmd("rm", ["-r", @dirname])
     _ = System.cmd("mkdir", ["-p", @dirname])
     _ = System.cmd("touch", [tarball])
     :ok

--- a/lib/aot_web/controllers/node_controller.ex
+++ b/lib/aot_web/controllers/node_controller.ex
@@ -2,6 +2,7 @@ defmodule AotWeb.NodeController do
   use AotWeb, :controller
 
   import AotWeb.ControllerUtils, only: [
+    meta: 3,
     resp_format: 1
   ]
 
@@ -35,7 +36,8 @@ defmodule AotWeb.NodeController do
 
     render conn, "index.json",
       nodes: nodes,
-      resp_format: fmt
+      resp_format: fmt,
+      meta: meta(&node_url/3, :index, conn)
   end
 
   def show(conn, %{"id" => vsn}) do

--- a/lib/aot_web/controllers/observation_controller.ex
+++ b/lib/aot_web/controllers/observation_controller.ex
@@ -1,6 +1,10 @@
 defmodule AotWeb.ObservationController do
   use AotWeb, :controller
 
+  import AotWeb.ControllerUtils, only: [
+    meta: 3
+  ]
+
   import AotWeb.GenericPlugs
 
   import AotWeb.ObservationPlugs
@@ -29,6 +33,9 @@ defmodule AotWeb.ObservationController do
 
   def index(conn, _params) do
     observations = ObservationActions.list(Map.to_list(conn.assigns))
-    render(conn, "index.json", observations: observations)
+
+    render conn, "index.json",
+      observations: observations,
+      meta: meta(&observation_url/3, :index, conn)
   end
 end

--- a/lib/aot_web/controllers/project_controller.ex
+++ b/lib/aot_web/controllers/project_controller.ex
@@ -2,6 +2,7 @@ defmodule AotWeb.ProjectController do
   use AotWeb, :controller
 
   import AotWeb.ControllerUtils, only: [
+    meta: 3,
     resp_format: 1
   ]
 
@@ -31,7 +32,8 @@ defmodule AotWeb.ProjectController do
 
     render conn, "index.json",
       projects: projects,
-      resp_format: fmt
+      resp_format: fmt,
+      meta: meta(&project_url/3, :index, conn)
   end
 
   def show(conn, %{"id" => slug}) do

--- a/lib/aot_web/controllers/raw_observation_controller.ex
+++ b/lib/aot_web/controllers/raw_observation_controller.ex
@@ -1,6 +1,10 @@
 defmodule AotWeb.RawObservationController do
   use AotWeb, :controller
 
+  import AotWeb.ControllerUtils, only: [
+    meta: 3
+  ]
+
   import AotWeb.GenericPlugs
 
   import AotWeb.NodePlugs, only: [
@@ -35,6 +39,8 @@ defmodule AotWeb.RawObservationController do
 
   def index(conn, _params) do
     observations = RawObservationActions.list(Map.to_list(conn.assigns))
-    render(conn, "index.json", raw_observations: observations)
+    render conn, "index.json",
+      raw_observations: observations,
+      meta: meta(&raw_observation_url/3, :index, conn)
   end
 end

--- a/lib/aot_web/controllers/sensor_controller.ex
+++ b/lib/aot_web/controllers/sensor_controller.ex
@@ -1,6 +1,10 @@
 defmodule AotWeb.SensorController do
   use AotWeb, :controller
 
+  import AotWeb.ControllerUtils, only: [
+    meta: 3
+  ]
+
   import AotWeb.GenericPlugs
 
   alias Aot.SensorActions
@@ -23,7 +27,8 @@ defmodule AotWeb.SensorController do
     sensors = SensorActions.list(Map.to_list(conn.assigns))
 
     render conn, "index.json",
-      sensors: sensors
+      sensors: sensors,
+      meta: meta(&sensor_url/3, :index, conn)
   end
 
   def show(conn, %{"id" => path}) do

--- a/lib/aot_web/plugs/observation_plugs.ex
+++ b/lib/aot_web/plugs/observation_plugs.ex
@@ -69,7 +69,10 @@ defmodule AotWeb.ObservationPlugs do
   Parses and validates use of the `as_histogram` parameter.
   """
   @spec as_histogram(Conn.t(), keyword()) :: Conn.t()
-  def as_histogram(%Conn{params: %{"as_histogram" => hist}} = conn, opts) do
+  def as_histogram(%Conn{params: %{"as_histogram" => nil}} = conn, _opts),
+    do: halt_with(conn, :bad_request, @hist_error)
+
+    def as_histogram(%Conn{params: %{"as_histogram" => hist}} = conn, opts) do
     case Regex.match?(@hist_regex, hist) do
       false ->
         halt_with(conn, :bad_request, @hist_error)

--- a/lib/aot_web/views/node_view.ex
+++ b/lib/aot_web/views/node_view.ex
@@ -5,8 +5,8 @@ defmodule AotWeb.NodeView do
 
   alias AotWeb.NodeView
 
-  def render("index.json", %{nodes: nodes, resp_format: fmt}) do
-    %{data: render_many(nodes, NodeView, "node.#{fmt}")}
+  def render("index.json", %{nodes: nodes, resp_format: fmt, meta: meta}) do
+    %{meta: meta, data: render_many(nodes, NodeView, "node.#{fmt}")}
   end
 
   def render("show.json", %{node: node, resp_format: fmt}) do

--- a/lib/aot_web/views/observation_view.ex
+++ b/lib/aot_web/views/observation_view.ex
@@ -5,12 +5,8 @@ defmodule AotWeb.ObservationView do
 
   alias AotWeb.ObservationView
 
-  def render("index.json", %{observations: observations}) do
-    %{data: render_many(observations, ObservationView, "observation.json")}
-  end
-
-  def render("show.json", %{observation: observation}) do
-    %{data: render_one(observation, ObservationView, "observation.json")}
+  def render("index.json", %{observations: observations, meta: meta}) do
+    %{meta: meta, data: render_many(observations, ObservationView, "observation.json")}
   end
 
   def render("observation.json", %{observation: obs}) do

--- a/lib/aot_web/views/project_view.ex
+++ b/lib/aot_web/views/project_view.ex
@@ -5,8 +5,8 @@ defmodule AotWeb.ProjectView do
 
   alias AotWeb.ProjectView
 
-  def render("index.json", %{projects: projects, resp_format: fmt}) do
-    %{data: render_many(projects, ProjectView, "project.#{fmt}")}
+  def render("index.json", %{projects: projects, resp_format: fmt, meta: meta}) do
+    %{meta: meta, data: render_many(projects, ProjectView, "project.#{fmt}")}
   end
 
   def render("show.json", %{project: project, resp_format: fmt}) do

--- a/lib/aot_web/views/raw_observation_view.ex
+++ b/lib/aot_web/views/raw_observation_view.ex
@@ -5,8 +5,8 @@ defmodule AotWeb.RawObservationView do
 
   alias AotWeb.RawObservationView
 
-  def render("index.json", %{raw_observations: obs}) do
-    %{data: render_many(obs, RawObservationView, "raw_observation.json")}
+  def render("index.json", %{raw_observations: obs, meta: meta}) do
+    %{meta: meta, data: render_many(obs, RawObservationView, "raw_observation.json")}
   end
 
   def render("show.json", %{raw_observation: obs}) do

--- a/lib/aot_web/views/sensor_view.ex
+++ b/lib/aot_web/views/sensor_view.ex
@@ -5,8 +5,8 @@ defmodule AotWeb.SensorView do
 
   alias AotWeb.SensorView
 
-  def render("index.json", %{sensors: sensors}) do
-    %{data: render_many(sensors, SensorView, "sensor.json")}
+  def render("index.json", %{sensors: sensors, meta: meta}) do
+    %{meta: meta, data: render_many(sensors, SensorView, "sensor.json")}
   end
 
   def render("show.json", %{sensor: sensor}) do

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Aot.Mixfile do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(env) when env in [:test, :travis], do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
@@ -50,7 +50,7 @@ defmodule Aot.Mixfile do
       {:quantum, "~> 2.3"},
 
       # testing
-      {:mock, "~> 0.3.2", only: :test},
+      {:mock, "~> 0.3.2", only: [:test, :travis]},
 
       # releases
       {:distillery, "~> 1.5"},

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Aot.Mixfile do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
 
   def project do
     [

--- a/test/aot_web/controllers/controller_utils_test.exs
+++ b/test/aot_web/controllers/controller_utils_test.exs
@@ -33,4 +33,116 @@ defmodule AotWeb.Testing.ControllerUtilsTest do
       end)
     end
   end
+
+  describe "meta" do
+    test "adds `meta` object to response", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      assert Map.has_key?(resp, "meta")
+    end
+
+    test "meta has `query` object", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      assert Map.has_key?(meta, "query")
+    end
+
+    test "query has all parsed parameters listed", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      query = Map.get(meta, "query")
+
+      ["paginate", "order"]
+      |> Enum.each(& assert Map.has_key?(query, &1))
+
+      resp =
+        conn
+        |> get(observation_path(conn, :index, barf: true))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      query = Map.get(meta, "query")
+
+      ["paginate", "order"]
+      |> Enum.each(& assert Map.has_key?(query, &1))
+      refute Map.has_key?(query, "barf")
+
+      resp =
+        conn
+        |> get(observation_path(conn, :index, embed_node: true))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      query = Map.get(meta, "query")
+
+      ["paginate", "order", "embed_node"]
+      |> Enum.each(& assert Map.has_key?(query, &1))
+    end
+
+    test "meta has `links` object", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      assert Map.has_key?(meta, "links")
+    end
+
+    test "links has previous, current and next links", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      links = Map.get(meta, "links")
+
+      ["previous", "current", "next"]
+      |> Enum.each(& assert Map.has_key?(links, &1))
+    end
+
+    @tag add2ctx: :projects
+    test "if call to :show, there is no metadata", %{conn: conn, chicago: chi} do
+      resp =
+        conn
+        |> get(project_path(conn, :show, chi))
+        |> json_response(:ok)
+
+      refute Map.has_key?(resp, "meta")
+    end
+
+    test "if page is 1, previous link is null", %{conn: conn} do
+      resp =
+        conn
+        |> get(observation_path(conn, :index))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      links = Map.get(meta, "links")
+
+      assert Map.has_key?(links, "previous") and Map.get(links, "previous") == nil
+
+      resp =
+        conn
+        |> get(observation_path(conn, :index, page: 2))
+        |> json_response(:ok)
+
+      meta = Map.get(resp, "meta")
+      links = Map.get(meta, "links")
+
+      assert Map.has_key?(links, "previous") and Map.get(links, "previous") != nil
+    end
+  end
 end


### PR DESCRIPTION
## Suppressed File Stat Warning

We just did a blank `rm -r @dirname` and that was causing a lot of
unnecessary warning output while testing.

I added an explicit check before the call to `rm` to get rid of all the
obnoxious output.

## Added Metadata to Index Responses

This adds a new `meta` object to the responses. Metadata includes links
to previous, current and next URLs, and it includes a breakdown of the
query parameters parsed and used to formulate the query behind the
response data.

### Bump Version 