### PR TITLE
API root should return JSON

### DIFF
--- a/lib/aot_web/controllers/docs_controller.ex
+++ b/lib/aot_web/controllers/docs_controller.ex
@@ -1,7 +1,33 @@
 defmodule AotWeb.DocsController do
   use AotWeb, :controller
 
+  import AotWeb.Router.Helpers
+
   @docs Application.get_env(:aot, :docs_url)
 
-  def show(conn, _), do: redirect(conn, external: @docs)
+  def apiary(conn, _), do: redirect(conn, external: @docs)
+
+  def json_links(conn, _) do
+    body =
+      %{
+        docs: @docs,
+        endpoints: %{
+          projects: project_url(conn, :index),
+          nodes: node_url(conn, :index),
+          sensors: sensor_url(conn, :index),
+          observations: observation_url(conn, :index),
+          raw_observations: raw_observation_url(conn, :index)
+        },
+        clients: %{
+          python: "https://github.com/UrbanCCD-UChicago/aot-client-py",
+          javascript: "https://github.com/UrbanCCD-UChicago/aot-client-js",
+          r: "https://github.com/UrbanCCD-UChicago/aot-client-r",
+        }
+      }
+      |> Jason.encode!()
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, body)
+  end
 end

--- a/lib/aot_web/router.ex
+++ b/lib/aot_web/router.ex
@@ -11,14 +11,16 @@ defmodule AotWeb.Router do
   end
 
   scope "/", AotWeb do
-    get "/", DocsController, :show
-    get "/docs", DocsController, :show
-    get "/api", DocsController, :show
-    get "/api/docs", DocsController, :show
+    get "/", DocsController, :apiary
+    get "/docs", DocsController, :apiary
   end
 
   scope "/api", AotWeb do
     pipe_through :api
+
+    # docs paths
+    get "/", DocsController, :json_links
+    get "/docs", DocsController, :json_links
 
     resources "/projects", ProjectController, only: [:index, :show]
     resources "/nodes", NodeController, only: [:index, :show]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Aot.Mixfile do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.3.3"
 
   def project do
     [

--- a/test/aot_web/controllers/docs_controller_test.exs
+++ b/test/aot_web/controllers/docs_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule AotWeb.Testing.DocsControllerTest do
+  use Aot.Testing.BaseCase
+  use AotWeb.Testing.ConnCase
+
+  describe "apiary redirect" do
+    test "/", %{conn: conn} do
+      conn
+      |> get("/")
+      |> html_response(:found)
+    end
+
+    test "/docs", %{conn: conn} do
+      conn
+      |> get("/docs")
+      |> html_response(:found)
+    end
+  end
+
+  describe "json links" do
+    test "/api", %{conn: conn} do
+      conn
+      |> get("/api")
+      |> json_response(:ok)
+    end
+
+    test "/api/docs", %{conn: conn} do
+      conn
+      |> get("/api/docs")
+      |> json_response(:ok)
+    end
+  end
+end


### PR DESCRIPTION
It's kind of jarring to send a request, expect JSON and then get hit
with a wall of text because somebody set up a redirect to an HTML
site.

When users now hit the base `/api` route they will get a JSON
response with links to the docs and other relevant material.

Fixes #10