### PR TITLE
Fix First/Last Aggs Errors

### DIFF
--- a/lib/aot/queries/observation_queries.ex
+++ b/lib/aot/queries/observation_queries.ex
@@ -160,15 +160,13 @@ defmodule Aot.ObservationQueries do
 
   def value(query, :first),
     do: from obs in query,
-      select: %{
-        first: fragment("first(value, timestamp)")
-      }
+      order_by: [desc: obs.timestamp],
+      limit: 1
 
   def value(query, :last),
     do: from obs in query,
-      select: %{
-        last: fragment("last(value, timestamp)")
-      }
+      order_by: [asc: obs.timestamp],
+      limit: 1
 
   def value(query, {:count, grouper}),
     do: from obs in query,

--- a/lib/aot_web/controllers/controller_utils.ex
+++ b/lib/aot_web/controllers/controller_utils.ex
@@ -112,6 +112,10 @@ defmodule AotWeb.ControllerUtils do
   defp prev_link(url_func, controller_func, %Conn{params: %{"page" => page} = params} = conn),
     do: url_func.(conn, controller_func, Map.put(params, "page", page - 1))
 
+  defp prev_link(_, _, _), do: nil
+
   defp next_link(url_func, controller_func, %Conn{params: %{"page" => page} = params} = conn),
     do: url_func.(conn, controller_func, Map.put(params, "page", page + 1))
+
+  defp next_link(_, _, _), do: nil
 end

--- a/lib/aot_web/views/observation_view.ex
+++ b/lib/aot_web/views/observation_view.ex
@@ -10,7 +10,7 @@ defmodule AotWeb.ObservationView do
   end
 
   def render("observation.json", %{observation: obs}) do
-    case Map.has_key?(obs, :node_vsn) do
+    case Map.has_key?(obs, :timestamp) do
       true -> do_render(:obs, obs)
       false -> do_render(:agg, obs)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Aot.Mixfile do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
 
   def project do
     [

--- a/test/aot/queries/observation_queries_test.exs
+++ b/test/aot/queries/observation_queries_test.exs
@@ -33,13 +33,13 @@ defmodule Aot.Testing.ObservationQueriesTest do
     end
 
     test "first" do
-      [%{first: first_obs}] = ObservationActions.list(value: :first)
-      assert is_float(first_obs)
+      obs = ObservationActions.list(value: :first)
+      assert length(obs) == 1
     end
 
     test "last" do
-      [%{last: last_obs}] = ObservationActions.list(value: :last)
-      assert is_float(last_obs)
+      obs = ObservationActions.list(value: :last)
+      assert length(obs) == 1
     end
 
     test "count" do


### PR DESCRIPTION
The API was a little too naive in the way that it applied pagination and
ordering. In the case of calling `first` or `last` value aggregates for
observations, the defaults applied would break the query.

To solve this, I changed the underlying query to only grab the latest
record rather than using TimescaleDB's functions (which don't really do
what I wanted to do anyway). I also updated the ordering and pagination
plugs to have keyword lists of assigned key/values on the connection act
as short circuits.

Fixes #15