### PR TITLE
Ensure List Params are Lists

### DIFF
--- a/lib/aot_web/controllers/node_controller.ex
+++ b/lib/aot_web/controllers/node_controller.ex
@@ -14,6 +14,7 @@ defmodule AotWeb.NodeController do
 
   action_fallback AotWeb.FallbackController
 
+  plug :ensure_list, params: ~w(within_projects within_projects_exact has_sensors has_sensors_exact)
   plug :assign_if_exists, param: "include_projects", value_override: true
   plug :assign_if_exists, param: "include_sensors", value_override: true
   plug :assign_if_exists, param: "assert_alive", value_override: true

--- a/lib/aot_web/controllers/observation_controller.ex
+++ b/lib/aot_web/controllers/observation_controller.ex
@@ -15,6 +15,7 @@ defmodule AotWeb.ObservationController do
 
   alias Aot.ObservationActions
 
+  plug :ensure_list, params: ~w(of_projects from_nodes by_sensors)
   plug :assign_if_exists, param: "embed_node", value_override: true
   plug :assign_if_exists, param: "embed_sensor", value_override: true
   plug :assign_if_exists, param: "of_project"

--- a/lib/aot_web/controllers/project_controller.ex
+++ b/lib/aot_web/controllers/project_controller.ex
@@ -14,6 +14,7 @@ defmodule AotWeb.ProjectController do
 
   action_fallback AotWeb.FallbackController
 
+  plug :ensure_list, params: ~w(has_nodes has_nodes_exact has_sensors has_sensors_exact)
   plug :assign_if_exists, param: "include_nodes", value_override: true
   plug :assign_if_exists, param: "include_sensors", value_override: true
   plug :assign_if_exists, param: "has_node"

--- a/lib/aot_web/controllers/raw_observation_controller.ex
+++ b/lib/aot_web/controllers/raw_observation_controller.ex
@@ -19,6 +19,7 @@ defmodule AotWeb.RawObservationController do
 
   alias Aot.RawObservationActions
 
+  plug :ensure_list, params: ~w(of_projects from_nodes by_sensors)
   plug :assign_if_exists, param: "embed_node", value_override: true
   plug :assign_if_exists, param: "embed_sensor", value_override: true
   plug :assign_if_exists, param: "of_project"

--- a/lib/aot_web/controllers/sensor_controller.ex
+++ b/lib/aot_web/controllers/sensor_controller.ex
@@ -11,6 +11,7 @@ defmodule AotWeb.SensorController do
 
   action_fallback AotWeb.FallbackController
 
+  plug :ensure_list, params: ~w(observes_project observes_project_exact onboard_nodes onboard_nodes_exact)
   plug :assign_if_exists, param: "include_projects", value_override: true
   plug :assign_if_exists, param: "include_nodes", value_override: true
   plug :assign_if_exists, param: "observes_project"

--- a/test/aot_web/plugs/generic_plug_test.exs
+++ b/test/aot_web/plugs/generic_plug_test.exs
@@ -3,6 +3,37 @@ defmodule AotWeb.GenericPlugsTest do
   use Aot.Testing.DataCase
   use AotWeb.Testing.ConnCase
 
+  describe "ensure_list" do
+    test "when no param is found, nothing is updated", %{conn: conn} do
+      %{"meta" => %{"query" => query}} =
+        conn
+        |> get(node_path(conn, :index))
+        |> json_response(:ok)
+
+      refute Map.has_key?(query, "within_projects")
+    end
+
+    test "updates single value params to lists", %{conn: conn} do
+      %{"meta" => %{"query" => query}} =
+        conn
+        |> get(node_path(conn, :index, within_projects: "chicago"))
+        |> json_response(:ok)
+
+      assert Map.has_key?(query, "within_projects")
+      assert is_list(query["within_projects"])
+    end
+
+    test "passes through good list values", %{conn: conn} do
+      %{"meta" => %{"query" => query}} =
+        conn
+        |> get(node_path(conn, :index, within_projects: ["chicago"]))
+        |> json_response(:ok)
+
+      assert Map.has_key?(query, "within_projects")
+      assert is_list(query["within_projects"])
+    end
+  end
+
   describe "apply_if_exists" do
     test "when no param is found, nothing is assigned", %{conn: conn} do
       %{"data" => data} =


### PR DESCRIPTION
For some parameters we expect list values, e.g.
`within_projects[]=chicago&whithin_projects[]=chicago-epa-colo`.
However, I've fielded a few bug reports where users are passing single
values rather than lists.

This patch checks parameters and ensures that if the underlying query
expression expects a list, it gets a list.

Fixes #16